### PR TITLE
Handle credential already in use error for all providers

### DIFF
--- a/Sources/CleevioAppleAuth/AppleAuthenticationProvider.swift
+++ b/Sources/CleevioAppleAuth/AppleAuthenticationProvider.swift
@@ -65,10 +65,7 @@ public final class AppleAuthenticationProvider: AuthenticationProvider {
 
         do {
             firebaseAuthResult = try await auth.signIn(with: credential.firebaseCredential, link: true)
-        } catch
-            let error as AuthErrorCode where 
-                error.code == .credentialAlreadyInUse ||
-                error.code == .missingOrInvalidNonce {
+        } catch let error as AuthErrorCode where error.code == .missingOrInvalidNonce {
             let updatedCredential = error.userInfo[AuthErrorUserInfoUpdatedCredentialKey] as? AuthCredential
             firebaseAuthResult = try await auth.signIn(with: updatedCredential ?? credential.firebaseCredential, link: false)
         }

--- a/Sources/CleevioFirebaseAuth/FirebaseAuthenticationService.swift
+++ b/Sources/CleevioFirebaseAuth/FirebaseAuthenticationService.swift
@@ -131,7 +131,6 @@ open class FirebaseAuthenticationService: FirebaseAuthenticationServiceType, @un
 
     private let auth: Auth
     public var user: FirebaseAuth.User? { auth.currentUser }
-    @MainActor
     public var presentingViewController: @MainActor () -> (PlatformViewController?) = { nil }
 
     public func signInAnonymously() async throws {

--- a/Sources/CleevioFirebaseAuth/FirebaseAuthenticationService.swift
+++ b/Sources/CleevioFirebaseAuth/FirebaseAuthenticationService.swift
@@ -164,11 +164,18 @@ open class FirebaseAuthenticationService: FirebaseAuthenticationServiceType, @un
      If the `link` parameter is set to `true` and there's a current user logged in, the provided `firebaseCredential` will be linked to the current user's account. Otherwise, the credential will be used for signing in.
      */
     @discardableResult
-    public func signIn(with firebaseCredential: AuthCredential, link: Bool = true) async throws -> AuthDataResult {
-        if let user, link {
-            return try await user.link(with: firebaseCredential)
-        } else {
+    public func signIn(with firebaseCredential: AuthCredential, link: Bool) async throws -> AuthDataResult {
+        guard let user, user.isAnonymous, link else {
             return try await auth.signIn(with: firebaseCredential)
+        }
+
+        do {
+            return try await user.link(with: firebaseCredential)
+        } catch let error as AuthErrorCode where error.code == .credentialAlreadyInUse {
+            let updatedCredential = error.userInfo[AuthErrorUserInfoUpdatedCredentialKey] as? AuthCredential
+            return try await auth.signIn(with: updatedCredential ?? firebaseCredential)
+        } catch {
+            throw error
         }
     }
 

--- a/Sources/CleevioGoogleAuth/GoogleAuthenticationProvider.swift
+++ b/Sources/CleevioGoogleAuth/GoogleAuthenticationProvider.swift
@@ -70,20 +70,9 @@ public final class GoogleAuthenticationProvider: AuthenticationProvider, NeedsPr
 
     public func authenticate(with auth: some FirebaseAuthenticationServiceType) async throws -> AuthenticationResult {
         let credential = try await credential()
-        let firebaseAuthResult: AuthDataResult
-
-        do {
-            firebaseAuthResult = try await auth.signIn(with: credential.firebaseCredential, link: true)
-        } catch let error as AuthErrorCode where error.code == .credentialAlreadyInUse {
-            let updatedCredentials = error.userInfo[AuthErrorUserInfoUpdatedCredentialKey] as? AuthCredential
-            firebaseAuthResult = try await auth.signIn(
-                with: updatedCredentials ?? credential.firebaseCredential,
-                link: false
-            )
-        }
 
         return AuthenticationResult(
-            firebaseAuthResult: firebaseAuthResult,
+            firebaseAuthResult: try await auth.signIn(with: credential.firebaseCredential, link: true),
             userData: nil
         )
     }


### PR DESCRIPTION
- handle credentialAlreadyInUse error collectively for all providers in case linking is not successful
- only try linking for anonymous users